### PR TITLE
[feat] : aop를 이용한 토큰 재발급

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
             <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
 
+        <!-- Spring AOP -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/src/main/java/shop/nhnteam04/front/aop/TokenExpiredReissueAop.java
+++ b/src/main/java/shop/nhnteam04/front/aop/TokenExpiredReissueAop.java
@@ -1,0 +1,47 @@
+package shop.nhnteam04.front.aop;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import shop.nhnteam04.front.exception.ExpiredAccessTokenException;
+import shop.nhnteam04.front.feign.account.AccountDirectFeignClient;
+import shop.nhnteam04.front.service.CookieService;
+import shop.nhnteam04.front.threadLocal.TokenHolder;
+import shop.nhnteam04.front.user.response.ResponseAccessToken;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class TokenExpiredReissueAop {
+    private final AccountDirectFeignClient accountDirectFeignClient;
+    private final HttpServletResponse response;
+    private final CookieService cookieService;
+
+    @Around("@within(org.springframework.cloud.openfeign.FeignClient)")
+    public Object tokenExpired(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object target = joinPoint.getTarget();
+        FeignClient annotation = target.getClass().getInterfaces()[0].getAnnotation(FeignClient.class);
+
+        if (annotation == null || !annotation.name().contains("gateway")) {
+            return joinPoint.proceed();
+        }
+
+        try {
+            return joinPoint.proceed();
+        } catch (ExpiredAccessTokenException e) {
+            ResponseAccessToken accessToken = accountDirectFeignClient.refresh();
+            TokenHolder.setAccessToken(accessToken.getAccessToken());
+            ResponseCookie cookie = cookieService.getAccessTokenCookie(accessToken.getAccessToken());
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+            return joinPoint.proceed();
+        }
+    }
+}

--- a/src/main/java/shop/nhnteam04/front/config/FeignAuthConfig.java
+++ b/src/main/java/shop/nhnteam04/front/config/FeignAuthConfig.java
@@ -4,16 +4,27 @@ import feign.RequestInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import shop.nhnteam04.front.threadLocal.TokenHolder;
+import feign.codec.ErrorDecoder;
+import shop.nhnteam04.front.feign.FeignErrorDecoder;
 
 @Configuration
 public class FeignAuthConfig {
     @Bean
     public RequestInterceptor requestInterceptor() {
         return template -> {
-            String token = TokenHolder.get();
-            if (token != null) {
-                template.header("Authorization", "Bearer " + token);
+            String accessToken = TokenHolder.getAccessToken();
+            String refreshToken = TokenHolder.getRefreshToken();
+            if (accessToken != null) {
+                template.header("Authorization", "Bearer " + accessToken);
+            }
+            if (refreshToken != null) {
+                template.header("AuthorizationRefresh", "Bearer " + refreshToken);
             }
         };
+    }
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new FeignErrorDecoder();
     }
 }

--- a/src/main/java/shop/nhnteam04/front/exception/ExpiredAccessTokenException.java
+++ b/src/main/java/shop/nhnteam04/front/exception/ExpiredAccessTokenException.java
@@ -1,0 +1,7 @@
+package shop.nhnteam04.front.exception;
+
+public class ExpiredAccessTokenException extends RuntimeException {
+    public ExpiredAccessTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/shop/nhnteam04/front/feign/FeignErrorDecoder.java
+++ b/src/main/java/shop/nhnteam04/front/feign/FeignErrorDecoder.java
@@ -1,0 +1,25 @@
+package shop.nhnteam04.front.feign;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import shop.nhnteam04.front.exception.ExpiredAccessTokenException;
+
+import java.util.List;
+
+public class FeignErrorDecoder implements ErrorDecoder {
+    private final ErrorDecoder defaultDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+
+        String errorCode = response.headers()
+                .getOrDefault("X-Error-Code", List.of())
+                .stream().findFirst().orElse("");
+
+        if ("EXPIRED_TOKEN".equals(errorCode)) {
+            return new ExpiredAccessTokenException("Access Token expired");
+        }
+
+        return defaultDecoder.decode(methodKey, response);
+    }
+}

--- a/src/main/java/shop/nhnteam04/front/feign/account/AccountDirectFeignClient.java
+++ b/src/main/java/shop/nhnteam04/front/feign/account/AccountDirectFeignClient.java
@@ -1,0 +1,11 @@
+package shop.nhnteam04.front.feign.account;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import shop.nhnteam04.front.user.response.ResponseAccessToken;
+
+@FeignClient(name= "account-api")
+public interface AccountDirectFeignClient {
+    @PostMapping("/api/token/refresh")
+    public ResponseAccessToken refresh();
+}

--- a/src/main/java/shop/nhnteam04/front/feign/account/AccountFeignClient.java
+++ b/src/main/java/shop/nhnteam04/front/feign/account/AccountFeignClient.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import shop.nhnteam04.front.config.FeignAuthConfig;
 import shop.nhnteam04.front.user.request.LoginRequestUser;
 import shop.nhnteam04.front.user.response.LoginResponse;
+import shop.nhnteam04.front.user.response.ResponseAccessToken;
 import shop.nhnteam04.front.user.response.ResponseUserWithPolicy;
 
 @FeignClient(name= "gateway/account-api")

--- a/src/main/java/shop/nhnteam04/front/interceptor/TokenHeaderInterceptor.java
+++ b/src/main/java/shop/nhnteam04/front/interceptor/TokenHeaderInterceptor.java
@@ -11,8 +11,12 @@ public class TokenHeaderInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String accessToken = getTokenFromCookie(request, "access_token");
+        String refreshToken = getTokenFromCookie(request, "refresh_token");
         if (accessToken != null) {
-            TokenHolder.set(accessToken);
+            TokenHolder.setAccessToken(accessToken);
+        }
+        if (refreshToken != null) {
+            TokenHolder.setRefreshToken(refreshToken);
         }
         return true;
     }

--- a/src/main/java/shop/nhnteam04/front/service/CookieService.java
+++ b/src/main/java/shop/nhnteam04/front/service/CookieService.java
@@ -1,0 +1,38 @@
+package shop.nhnteam04.front.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CookieService {
+
+
+    private static final Long ACCESS_TOKEN_EXPIRES = 1800 * 1000L;
+    private static final Long REFRESH_TOKEN_EXPIRES = 24 * 60 * 60 * 1000L;
+
+    @Value("${cookie.domain:}")
+    private String cookieDomain;
+    @Value("${cookie.secure:false}")
+    private boolean cookieSecure;
+
+    public ResponseCookie getAccessTokenCookie(String token) {
+        return getResponseCookie("access_token", token, ACCESS_TOKEN_EXPIRES);
+    }
+
+    public ResponseCookie getRefreshTokenCookie(String token) {
+        return getResponseCookie("refresh_token", token, REFRESH_TOKEN_EXPIRES);
+    }
+
+
+    private ResponseCookie getResponseCookie(String tokenName, String token, Long tokenExpires) {
+        return ResponseCookie.from(tokenName, token)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .domain(cookieDomain)
+                .maxAge(tokenExpires)
+                .sameSite("Lax")
+                .build();
+    }
+}

--- a/src/main/java/shop/nhnteam04/front/service/LoginService.java
+++ b/src/main/java/shop/nhnteam04/front/service/LoginService.java
@@ -10,30 +10,23 @@ import org.springframework.stereotype.Service;
 import shop.nhnteam04.front.feign.account.AccountFeignClient;
 import shop.nhnteam04.front.user.request.LoginRequestUser;
 import shop.nhnteam04.front.user.response.LoginResponse;
-import org.springframework.beans.factory.annotation.Value;
 import shop.nhnteam04.front.user.response.ResponseUserWithPolicy;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class LoginService {
+
     private final AccountFeignClient accountFeignClient;
-    private static final Long ACCESS_TOKEN_EXPIRES = 1800 * 1000L;
-    private static final Long REFRESH_TOKEN_EXPIRES = 24 * 60 * 60 * 1000L;
-
-    @Value("${cookie.domain:}")
-    private String cookieDomain;
-    @Value("${cookie.secure:false}")
-    private boolean cookieSecure;
-
+    private final CookieService cookieService;
 
     public void login(LoginRequestUser loginRequestUser, HttpServletResponse response) {
        LoginResponse loginResponse = accountFeignClient.login(loginRequestUser);
        log.info("login response: {}", loginResponse);
 
-        ResponseCookie accessTokenCookie = getResponseCookie("access_token", loginResponse.getAccessToken(), ACCESS_TOKEN_EXPIRES);
+        ResponseCookie accessTokenCookie = cookieService.getAccessTokenCookie(loginResponse.getAccessToken());
 
-        ResponseCookie refreshTokenCookie = getResponseCookie("refresh_token", loginResponse.getRefreshToken(), REFRESH_TOKEN_EXPIRES);
+        ResponseCookie refreshTokenCookie = cookieService.getRefreshTokenCookie(loginResponse.getRefreshToken());
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
@@ -43,15 +36,4 @@ public class LoginService {
         return accountFeignClient.me();
     }
 
-    private ResponseCookie getResponseCookie(String tokenName, String token, Long tokenExpires) {
-        ResponseCookie accessTokenCookie = ResponseCookie.from(tokenName, token)
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .path("/")
-                .domain(cookieDomain)
-                .maxAge(tokenExpires)
-                .sameSite("Lax")
-                .build();
-        return accessTokenCookie;
-    }
 }

--- a/src/main/java/shop/nhnteam04/front/threadLocal/TokenHolder.java
+++ b/src/main/java/shop/nhnteam04/front/threadLocal/TokenHolder.java
@@ -1,17 +1,27 @@
 package shop.nhnteam04.front.threadLocal;
 
 public class TokenHolder {
-    private static final ThreadLocal<String> token = new ThreadLocal<>();
+    private static final ThreadLocal<String> accessToken = new ThreadLocal<>();
+    private static final ThreadLocal<String> refreshToken = new ThreadLocal<>();
 
-    public static void set(String value) {
-        token.set(value);
+    public static void setAccessToken(String value) {
+        accessToken.set(value);
     }
 
-    public static String get() {
-        return token.get();
+    public static String getAccessToken() {
+        return accessToken.get();
+    }
+
+    public static void setRefreshToken(String value) {
+        refreshToken.set(value);
+    }
+
+    public static String getRefreshToken() {
+        return refreshToken.get();
     }
 
     public static void clear() {
-        token.remove();
+        accessToken.remove();
+        refreshToken.remove();
     }
 }

--- a/src/main/java/shop/nhnteam04/front/user/response/ResponseAccessToken.java
+++ b/src/main/java/shop/nhnteam04/front/user/response/ResponseAccessToken.java
@@ -1,0 +1,12 @@
+package shop.nhnteam04.front.user.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseAccessToken {
+    private String accessToken;
+}


### PR DESCRIPTION
## 변경 사항

- aop로 feignclient를 타겟으로하고 또 gateway가 들어간 feignclient만 적용하도록 함
- 재발급 후 토큰홀더에 저장및 쿠키로도 저장

## 관련 이슈

## 체크리스트

- [ ] 코드가 빌드되고 있나요?
- [ ] 테스트가 성공적으로 동작하나요?
- [ ] 코드 스타일 규칙을 따르고 있나요?
